### PR TITLE
fixing Error in 'SearchParser': Mismatched ']'. message in DetectionI…

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -43,4 +43,4 @@ search = | rest /services/datamodel/model \
 | table title, accelerated, size, average_time, last_error \
 | fillnull size, average_time \
 | rename title as datamodel \
-| outputlookup all_datamodels.csv]
+| outputlookup all_datamodels.csv


### PR DESCRIPTION
An extra square bracket ']' in the **DetectionInsight - All Datamodels - Lookup Gen** search was causing the search to fail with the _Error in 'SearchParser': Mismatched ']'_ message, breaking the **Detection details** panel. Removing the character fixed the issue.